### PR TITLE
Fix misspelling in the Red Line Advisory section

### DIFF
--- a/views/workshop-info.erb
+++ b/views/workshop-info.erb
@@ -19,7 +19,7 @@
 
     <h2>Red Line Advisory</h2>
     <p>
-      <em>Upate: Due to snowfall forecasts this weekend, this diversion between Harvard Square
+      <em>Update: Due to snowfall forecasts this weekend, this diversion between Harvard Square
       and Alewife Station on February 23-24 has been cancelled and will be rescheduled at a later date.</em>
       <br/>
       Buses will replace Red Line trains between Harvard and Alewife Stations on the weekend of February 23-24


### PR DESCRIPTION
Just a single missing character. ;)
