### PR TITLE
Use get over match in router

### DIFF
--- a/public/presentations/router.html
+++ b/public/presentations/router.html
@@ -5079,7 +5079,7 @@ DELETE /topics/42
         
           <div class="">
             <div id="slide-19" class="content">
-              <h1>Lying with Routes</h1><p>http://www.urbandictionary.com/define.php?term=ruby+on+rails</p><div class="highlight ruby code highlight"><pre><span class="n">match</span> <span class="s1">'/define.php'</span> <span class="o">=&gt;</span> <span class="s1">'definitions#show'</span>
+              <h1>Lying with Routes</h1><p>http://www.urbandictionary.com/define.php?term=ruby+on+rails</p><div class="highlight ruby code highlight"><pre><span class="n">get</span> <span class="s1">'/define.php'</span> <span class="o">=&gt;</span> <span class="s1">'definitions#show'</span>
 </pre></div>
             </div>
           </div>


### PR DESCRIPTION
Using match will route any http method, whereas get will only match GET 
requests.
