### PR TITLE
Remove 'Registration is open' and enhance 'sign up for next time'

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -99,10 +99,9 @@
           <a href="http://microsoftcambridge.com/About/Directions/tabid/89/Default.aspx">Directions to the NERD Center</a>
         </address>
       </p>
-      <h3>Registration is open!</h3>
-      <p><a href="http://railsbridgeboston062013.eventbrite.com">Sign up here.</a></p>
       <p>
-        Can't attend on this date? <a href="http://eepurl.com/vwrQT">Sign up here to be notified when we announce the next workhop</a>.
+        <strong>Weren't able to attend this session?</strong><br />
+        <a href="http://eepurl.com/vwrQT">Sign up here to get advance notice</a> when we announce the next workhop.
       </p>
       <p>
         <a href="https://docs.google.com/spreadsheet/viewform?formkey=dGdzbFUwb2NfY1pPenhGcGJ1MnBvdlE6MA" class="btn btn-large">TAs: Apply Here</a>


### PR DESCRIPTION
... on home page. Closes #56.

We should remove the red "Registration is open!" link at this point.
