### PR TITLE
Use long switches when checking versions.

### DIFF
--- a/views/installfest.markdown
+++ b/views/installfest.markdown
@@ -62,7 +62,7 @@ Find a staff member and run through this checklist:
 2. Confirm that Ruby and Rails are installed on your machine.  From the command line type:
 
     ```text
-    rails -v
+    rails --version
     ```
     
     If you are on Mac you should see:

--- a/views/installfest/install/linux.markdown
+++ b/views/installfest/install/linux.markdown
@@ -87,7 +87,7 @@ instructor to help diagnose the installation issue.
 8. Close an re-open your terminal and confirm Ruby is installed properly
 
     ```text
-    ruby -v
+    ruby --version
     ```
 
     You should get something similar to `ruby 1.9.3p286 (2012-10-12 revision 37165) [i616-linux]` 

--- a/views/installfest/install/osx-10-5.markdown
+++ b/views/installfest/install/osx-10-5.markdown
@@ -69,7 +69,7 @@ rbenv global 1.9.3-p286
 ### 9. Close an re-open your terminal and confirm Ruby is installed properly
 
 ```text
-ruby -v
+ruby --version
 ```
 
 You should get something similar to `ruby 1.9.3p286 (2012-10-12 revision 37165) [x86_64-darwin12.2.0]`


### PR DESCRIPTION
Someone asked last weekend about the inconsistency when checking versions of the tools. Some use `-v`, some use `--version`. Since all of the tools support the long switch, let's use that. Plus the long switch is easier for beginners to understand. This commit only updates the version switch, but I'll be on the lookout to replace short switches unless someone argues otherwise.
