### PR TITLE
Further corrections to installfest text editor install instructions, especially around Linux installs.

### DIFF
--- a/views/installfest/text_editor.markdown
+++ b/views/installfest/text_editor.markdown
@@ -50,18 +50,11 @@ sudo apt-get install sublime-text
 You can then start it from the same terminal window with:
 ```text
 /usr/bin/sublime-text
-'''
+```
 However, a pretty icon has also been created, and you can start it from the Graphical User Interface (GUI)
 
 Sorry we don't have instructions ready yet for Fedora, so please ask a
 TA tonight for help.
-
-For Mint and other non-Ubuntu distros, type these commands in the Terminal:
-
-```text
-sudo apt-get update
-sudo apt-get install gedit-plugins
-```
 
 ### 2. Open your Editor
 
@@ -84,9 +77,9 @@ Finder.
 Type this in the Terminal to start gEdit:
 
 ```text
-gedit
+/usr/bin/sublime-text
 ```
-
+Or, you can use your GUIs menus, as an icon has most likely been installed.
 
 ### 3. Set some basic preferences
 

--- a/views/installfest/text_editor.markdown
+++ b/views/installfest/text_editor.markdown
@@ -62,7 +62,7 @@ Sorry we don't have instructions ready for Fedora, so please ask a TA for help.
 1. To start Sublime Text 2 please select it from the Start Menu under
    'All Programs'
 
-![Submlime Text 2](/public/images/installfest/sublime2.png?raw=true)
+![Submlime Text 2](../../public/images/installfest/sublime2.png?raw=true)
 
 #### OSX
 

--- a/views/installfest/text_editor.markdown
+++ b/views/installfest/text_editor.markdown
@@ -62,7 +62,7 @@ Sorry we don't have instructions ready for Fedora, so please ask a TA for help.
 1. To start Sublime Text 2 please select it from the Start Menu under
    'All Programs'
 
-![Submlime Text 2](/images/installfest/sublime2.png)
+![Submlime Text 2](/public/images/installfest/sublime2.png)
 
 #### OSX
 

--- a/views/installfest/text_editor.markdown
+++ b/views/installfest/text_editor.markdown
@@ -39,15 +39,19 @@ sudo ln -s "/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl" /u
 ```
 
 #### Linux
+These are directions tested for Kubuntu/Ubuntu version 13.04, although it will probably work on other distributions such as Mint.
 
-
-If you use Ubuntu, type these commands in the Terminal:
-
+Open a terminal window, and enter these commands:
 ```text
-sudo add-apt-repository ppa:ubuntu-on-rails
+sudo add-apt-repository ppa:webupd8team/sublime-text-2
 sudo apt-get update
-sudo apt-get install gedit-plugins gedit-gmate
+sudo apt-get install sublime-text
 ```
+You can then start it from the same terminal window with:
+```text
+/usr/bin/sublime-text
+'''
+However, a pretty icon has also been created, and you can start it from the Graphical User Interface (GUI)
 
 Sorry we don't have instructions ready yet for Fedora, so please ask a
 TA tonight for help.

--- a/views/installfest/text_editor.markdown
+++ b/views/installfest/text_editor.markdown
@@ -74,7 +74,7 @@ Finder.
 
 #### Linux
 
-Type this in the Terminal to start gEdit:
+Type this in the Terminal to start Sublime:
 
 ```text
 /usr/bin/sublime-text

--- a/views/installfest/text_editor.markdown
+++ b/views/installfest/text_editor.markdown
@@ -53,8 +53,7 @@ You can then start it from the same terminal window with:
 ```
 However, a pretty icon has also been created, and you can start it from the Graphical User Interface (GUI)
 
-Sorry we don't have instructions ready yet for Fedora, so please ask a
-TA tonight for help.
+Sorry we don't have instructions ready for Fedora, so please ask a TA for help.
 
 ### 2. Open your Editor
 
@@ -83,8 +82,6 @@ Or, you can use your GUIs menus, as an icon has most likely been installed.
 
 ### 3. Set some basic preferences
 
-#### If you are using Sublime Text 2
-
 Sublime Text 2 reads its preferences from text files. This means you can easily
 edit settings, check your settings into version control, or share settings with
 copy & paste. That's what we're going to do with some common preferences for
@@ -103,14 +100,6 @@ Open up User Settings (`Sublime Text 2 > Preferences > Settings - User`) and pas
 ```
 
 Save the User Settings file (`File > Save`). Your new preferences are now in effect.
-
-#### If you are using gEdit 
-
-Go to Edit > Preferences and click the Editor tab. Set the `Tab width`
-option to 2 and make sure `Insert spaces instead of tabs` and `Enable
-automatic indentation` are checked.
-
-![](/images/gedit-pref.png)
 
 ### Success!
 

--- a/views/installfest/text_editor.markdown
+++ b/views/installfest/text_editor.markdown
@@ -62,7 +62,7 @@ Sorry we don't have instructions ready for Fedora, so please ask a TA for help.
 1. To start Sublime Text 2 please select it from the Start Menu under
    'All Programs'
 
-![Submlime Text 2](/public/images/installfest/sublime2.png)
+![Submlime Text 2](/public/images/installfest/sublime2.png?raw=true)
 
 #### OSX
 


### PR DESCRIPTION
However, I'm beginning to think these should be broken up into various platforms (Mac, Linux, Windows). Have the install instructions, and launch instructions, then bring them all back to the preferences settings.
