### PR TITLE
Break homepage content into separate pages

### DIFF
--- a/public/stylesheets/site.css
+++ b/public/stylesheets/site.css
@@ -42,6 +42,11 @@ h3 {
           border-radius: 0 0 4px 4px;
 }
 
+.btn-primary {
+  background-image: linear-gradient(rgb(231,66,34), rgb(231,66,34) 90%, #D85333);
+  background-color: inherit;
+}
+
 /* Space out sub-sections more
 -------------------------------------------------- */
 section {

--- a/views/about.erb
+++ b/views/about.erb
@@ -1,0 +1,51 @@
+<section id="about-page">
+  <div class="page-header">
+    <h1>About RailsBridge Boston</h1>
+  </div>
+
+  <div class="row">
+    <div class="span6">
+      <h3>Empowering Women with Ruby</h3>
+      <p>
+        Do you dream of someday writing software that helps people and improves the world?
+      </p>
+      <p>
+        Led by an all-volunteer team of seasoned, enthusiastic Ruby and Rails developers, the workshop introduces women of all backgrounds  to the concepts, tools, and techniques of Ruby and Rails development. Our audience is those with no or little programming experience.
+      </p>
+      <p>
+        We welcome you to the Boston Ruby community. Whatever your goal is in learning to program, we hope to connect you with the tools to take the next step.
+      </p>
+
+      <h3>Promoting Diversity</h3>
+      <p>
+        The Boston software scene needs more women. So this workshop is for women and their guests. You should identify as a woman, or be the male guest of a woman who is attending.
+      </p>
+      <p>
+        We support mothers who want to code. We will provide childcare to those who need it. Please let us know if you want to
+        use these services on the application form.
+      </p>
+
+      <h2>Contact</h2>
+      <ul>
+        <li>Follow us on Twitter: <a href="https://twitter.com/RailsBridgeBos">@RailsBridgeBos</a>.</li>
+        <li>Email us directly: <a href="mailto:railsbridgeboston@gmail.com">railsbridgeboston@gmail.com</a>.</li>
+        <li>If you graduated from or volunteered at one of our workshops, join our <a href="https://groups.google.com/forum/?fromgroups#!forum/railsbridge-boston-alumni">RailsBridge Boston Alumni Google Group</a>.</li>
+        <li>Tell us how we can improve our curriculum at <a href="https://github.com/railsbridge-boston/railsbridge-boston/issues">GitHub</a>.</li>
+      </ul>
+
+      <h2>Links</h2>
+      <ul>
+        <li><a href="http://workshops.railsbridge.org/">RailsBridge</a>: The original San Francisco Ruby on Rails workshop that made our effort possible.</li>
+        <li><a href="https://openhatch.org">OpenHatch</a>: Our wonderful outreach effort mentors.</li>
+        <li><a href="http://bostonrb.org">BostonRB</a>: The official local Ruby user group, and a wonderful community of helpful Rubyists.</li>
+      </ul>
+    </div>
+
+    <div class="span6 column-of-images">
+      <img src="/images/mar_2013/table1-r.jpg" title="Credit: Rebecca Frankel"/>
+      <img src="/images/2012-nov/IMG_9813-sm.jpg" title="Credit: Rebecca Frankel"/>
+      <img src="/images/aug2012/michael_durrant.jpg" title="Credit: Rebecca Frankel"/>
+      <img src="/images/2012-nov/8176931541_b8bf30fac4_z_d.jpg" title="Credit: Braulio Carreno"/>
+    </div>
+  <div>
+</section>

--- a/views/blog.erb
+++ b/views/blog.erb
@@ -1,0 +1,21 @@
+<section id="recaps-page">
+  <div class="page-header">
+    <h1>Workshop Recaps</h1>
+  </div>
+  <div class="lead">
+    <p class="text-center">
+      Learn about how our previous workshops have gone!
+    </p>
+  </div>
+  <div class="sponsor-images row">
+    <div class="span12">
+      <ul>
+        <li><a href="/blog/2013_jun_recap">June 2013 @ NERD Center</a></li>
+        <li><a href="/blog/2013_mar_recap">March 2013 @ MIT</a></li>
+        <li><a href="/blog/2013_jan_recap">January 2013 @ intelligent.ly</a></li>
+        <li><a href="/blog/2012_nov_recap">November 2012 @ MIT</a></li>
+        <li><a href="/blog/2012_aug_recap">August 2012 @ Harvard Law School</a></li>
+      </ul>
+    </div>
+  </div>
+</section>

--- a/views/index.erb
+++ b/views/index.erb
@@ -42,16 +42,6 @@
         use these services on the application form.
       </p>
 
-
-      <h2 style="clear:left; padding-top: 32px;">Workshop Recaps</h2>
-      <ul>
-        <li><a href="/blog/2013_jun_recap">June 2013 @ NERD Center</a></li>
-        <li><a href="/blog/2013_mar_recap">March 2013 @ MIT</a></li>
-        <li><a href="/blog/2013_jan_recap">January 2013 @ intelligent.ly</a></li>
-        <li><a href="/blog/2012_nov_recap">November 2012 @ MIT</a></li>
-        <li><a href="/blog/2012_aug_recap">August 2012 @ Harvard Law School</a></li>
-      </ul>
-
       <h2>Contact</h2>
       <ul>
         <li>Follow us on Twitter: <a href="https://twitter.com/RailsBridgeBos">@RailsBridgeBos</a>.</li>

--- a/views/index.erb
+++ b/views/index.erb
@@ -9,19 +9,27 @@
         The <strong>RailsBridge Workshop</strong> is a free 1.5 day guided introduction to programming in  <a href="http://ruby-lang.org/">Ruby</a> and <a href="http://rubyonrails.org/">Ruby on Rails</a>.
       </p>
       <p>
-        Our next workshop will be January 24 and 25, 2014. We'll post a link to registration in January when it opens.  We recommend joining the <a href="http://eepurl.com/vwrQT"> announcement list</a> to be notified, as it fills quickly.
-
+        Our next workshop will be on <strong>January 24 and 25, 2014</strong> at the Microsoft New England Research &amp; Development Center.
       </p>
       <p>
-        <a href="https://docs.google.com/spreadsheet/viewform?formkey=dGdzbFUwb2NfY1pPenhGcGJ1MnBvdlE6MA" class="btn btn-large">TAs and organizers: Apply here</a>
+        <a href="http://eepurl.com/vwrQT" class="btn btn-large btn-primary">Get notified when registration opens</a>
       </p>
       <p>
-        Can't join us this time?  The next workshops will be held in May 2014. <a href="http://eepurl.com/vwrQT">Join the announcement list to be notified</a> when registration opens.
+        Can't join us this time?  The next workshop will be held in May 2014. <a href="http://eepurl.com/vwrQT">Join the announcement list to be notified</a> when registration opens.
+      </p>
+      <p>
+        Want to be a TA or an organizer? Apply <a href="https://docs.google.com/spreadsheet/viewform?formkey=dGdzbFUwb2NfY1pPenhGcGJ1MnBvdlE6MA">here</a>.
+      </p>
+      <p>
+        Read the latest <a href="/blog/2013_jun_recap">recap</a> to see what our workshops are like.
       </p>
     </div>
 
     <div class="span6">
-      <iframe src="http://player.vimeo.com/video/70699061" width="100%" height="400" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe> <p><a href="http://vimeo.com/70699061">RailsBridge Boston Video Teaser</a> from <a href="http://vimeo.com/railsbridgeboston">RailsBridge Boston</a> by <a href="http://www.a2vmedia.com/">A2V Media</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
+      <iframe src="http://player.vimeo.com/video/70699061" width="100%" height="400" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
+      <small class="pull-right">
+        <a href="http://vimeo.com/70699061">RailsBridge Boston Video Teaser</a> from <a href="http://vimeo.com/railsbridgeboston">RailsBridge Boston</a> by <a href="http://www.a2vmedia.com/">A2V Media</a> on <a href="https://vimeo.com">Vimeo</a>.
+      </small>
     </div>
   </div>
 </section>

--- a/views/index.erb
+++ b/views/index.erb
@@ -9,69 +9,19 @@
         The <strong>RailsBridge Workshop</strong> is a free 1.5 day guided introduction to programming in  <a href="http://ruby-lang.org/">Ruby</a> and <a href="http://rubyonrails.org/">Ruby on Rails</a>.
       </p>
       <p>
-        Our next workshop will be January 24 and 25, 2014. We'll post a link to registration in January when it opens.  We recommend joining the <a href="http://eepurl.com/vwrQT"> announcement list</a> to be notified, as it fills quickly. 
+        Our next workshop will be January 24 and 25, 2014. We'll post a link to registration in January when it opens.  We recommend joining the <a href="http://eepurl.com/vwrQT"> announcement list</a> to be notified, as it fills quickly.
 
       </p>
       <p>
         <a href="https://docs.google.com/spreadsheet/viewform?formkey=dGdzbFUwb2NfY1pPenhGcGJ1MnBvdlE6MA" class="btn btn-large">TAs and organizers: Apply here</a>
       </p>
       <p>
-        Can't join us this time?  The next workshops will be held in May 2014. <a href="http://eepurl.com/vwrQT">Join the announcement list to be notified</a> when registration opens. 
+        Can't join us this time?  The next workshops will be held in May 2014. <a href="http://eepurl.com/vwrQT">Join the announcement list to be notified</a> when registration opens.
       </p>
-      
-     
-      <h2>About RailsBridge Boston</h2>
-
-      <h3>Empowering Women with Ruby</h3>
-      <p>
-        Do you dream of someday writing software that helps people and improves the world?
-      </p>
-      <p>
-        Led by an all-volunteer team of seasoned, enthusiastic Ruby and Rails developers, the workshop introduces women of all backgrounds  to the concepts, tools, and techniques of Ruby and Rails development. Our audience is those with no or little programming experience. 
-      </p>
-      <p>
-        We welcome you to the Boston Ruby community. Whatever your goal is in learning to program, we hope to connect you with the tools to take the next step. 
-      </p>
-     
-      <h3>Promoting Diversity</h3>
-      <p>
-        The Boston software scene needs more women. So this workshop is for women and their guests. You should identify as a woman, or be the male guest of a woman who is attending.
-      </p>
-      <p>
-        We support mothers who want to code. We will provide childcare to those who need it. Please let us know if you want to
-        use these services on the application form.
-      </p>
-
-      <h2>Contact</h2>
-      <ul>
-        <li>Follow us on Twitter: <a href="https://twitter.com/RailsBridgeBos">@RailsBridgeBos</a>.</li>
-        <li>Email us directly: <a href="mailto:railsbridgeboston@gmail.com">railsbridgeboston@gmail.com</a>.</li>
-        <li>If you graduated from or volunteered at one of our workshops, join our <a href="https://groups.google.com/forum/?fromgroups#!forum/railsbridge-boston-alumni">RailsBridge Boston Alumni Google Group</a>.</li>
-        <li>Tell us how we can improve our curriculum at <a href="https://github.com/railsbridge-boston/railsbridge-boston/issues">GitHub</a>.</li>
-      </ul>
-
-      <h2>Links</h2>
-      <ul>
-        <li><a href="http://workshops.railsbridge.org/">RailsBridge</a>: The original San Francisco Ruby on Rails workshop that made our effort possible.</li>
-        <li><a href="https://openhatch.org">OpenHatch</a>: Our wonderful outreach effort mentors.</li>
-        <li><a href="http://bostonrb.org">BostonRB</a>: The official local Ruby user group, and a wonderful community of helpful Rubyists.</li>
-      </ul>
-
     </div>
 
-    <div class="span6 column-of-images">
+    <div class="span6">
       <iframe src="http://player.vimeo.com/video/70699061" width="100%" height="400" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe> <p><a href="http://vimeo.com/70699061">RailsBridge Boston Video Teaser</a> from <a href="http://vimeo.com/railsbridgeboston">RailsBridge Boston</a> by <a href="http://www.a2vmedia.com/">A2V Media</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
-
-      <hr/>
-
-      <img src="/images/mar_2013/table1-r.jpg" title="Credit: Rebecca Frankel"/>
-      <img src="/images/2012-nov/IMG_9813-sm.jpg" title="Credit: Rebecca Frankel"/>
-      <img src="/images/aug2012/michael_durrant.jpg" title="Credit: Rebecca Frankel"/>
-      <img src="/images/2012-nov/8176931541_b8bf30fac4_z_d.jpg" title="Credit: Braulio Carreno"/>
     </div>
   </div>
 </section>
-
-
-
-

--- a/views/navbar.erb
+++ b/views/navbar.erb
@@ -32,9 +32,12 @@
             </ul>
           </li>
 
-
           <li>
             <a href="/sponsors">Sponsors</a>
+          </li>
+
+          <li>
+            <a href="/blog">Recaps</a>
           </li>
         </ul>
       </div>

--- a/views/navbar.erb
+++ b/views/navbar.erb
@@ -10,6 +10,10 @@
 
       <div class="nav-collapse">
         <ul class="nav pull-right">
+          <li>
+            <a href="/about">About</a>
+          </li>
+
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">Workshop Info<b class="caret"></b></a>
             <ul class="dropdown-menu" role="menu">

--- a/web.rb
+++ b/web.rb
@@ -142,7 +142,7 @@ class RubyWorkshop < Sinatra::Base
   end
 
   get '/blog' do
-    erb :"blog/blog"
+    erb :blog
   end
 
   get '/blog/2013_jun_recap' do

--- a/web.rb
+++ b/web.rb
@@ -109,9 +109,9 @@ class RubyWorkshop < Sinatra::Base
     "OK"
   end
 
-  # completions for this workshop 
+  # completions for this workshop
   get '/completions' do
-    completions = DB["select page, count(distinct student_id) from completions inner join students using (student_id) \ 
+    completions = DB["select page, count(distinct student_id) from completions inner join students using (student_id) \
        where students.name is not null and students.ip = '64.119.130.114' and workshop = ? group by page", CURRENT_WORKSHOP].to_a
 
     total_students = DB["select count(*) as total from students where students.name is not null and students.ip = '64.119.130.114' and workshop = ?", CURRENT_WORKSHOP].first[:total]
@@ -124,6 +124,10 @@ class RubyWorkshop < Sinatra::Base
   get '/' do
     @sponsors = sponsor_url_logos
     erb :index
+  end
+
+  get '/about' do
+    erb :about
   end
 
   get '/sponsors' do
@@ -200,7 +204,6 @@ class RubyWorkshop < Sinatra::Base
   get '/installfest' do
     redirect '/friday'
   end
-    
 
   # This handles default routes for the markdown files in `views/`
   # Mostly added so that people who don't want to fuss with a Sinatra app can


### PR DESCRIPTION
- Moved About content and photos into an About page.
- Moved recap links to a Blog page.
