### PR TITLE
Rewrite pre_workshop page to focus on the VM method, copy Dan's VM setup instructions to new page

### DIFF
--- a/views/pre_workshop.markdown
+++ b/views/pre_workshop.markdown
@@ -1,65 +1,42 @@
 # Pre-workshop downloads
 
-Please download the pre-requisite software onto your laptop computer before you attend the workshop. This helps speed things up on Friday and helps prevent the WiFi network from getting clogged.
+Please download the pre-requisite software onto your laptop computer before you attend the workshop. This helps speed things up on Friday and helps prevent the Wi-Fi network from getting clogged.
 
+## OS X
 
-## OS X 10.6 and above:
+We recommend that you install a "virtual machine" containing all the software you need for the workshop. A virtual machine, or VM, keeps the needed software separate from the rest of your computer and can easily be removed if you only want to use it temporarily.
 
-Pick one of the following options. The main difference is that Option 1  will
-install Ruby and various tools directly into your computer operating system,
-whereas Option 2 will install a temporary and easy-to-remove "virtual machine"
-containing all the software you need for the workshop.
+1. Download [VirtualBox](http://download.virtualbox.org/virtualbox/4.2.18/VirtualBox-4.2.18-88780-OSX.dmg) for Mac. Run the installer after it downloads.
 
-### Option 1. RailsInstaller
+2. Download [Vagrant](http://files.vagrantup.com/packages/db8e7a9c79b23264da129f55cf8569167fc22415/Vagrant-1.3.3.dmg) for Mac. Run the installer after it downloads.
 
-Download Railsinstaller from the <a href="http://railsinstaller.org" target="_blank">RailsInstaller</a> webpage.
+Then, follow the instructions in [VM Setup](/vm_setup).
 
-Don't worry about watching the video. Just leave the download in your Downloads folder.
+#### Alternative Method
 
-### Option 2. Railsbridge Virtual Machine
+If your Mac has an operating system older than 10.6, or VirtualBox does not work for you, you can install Ruby and various tools directly into your computer. The easiest way to do this is with RailsInstaller.
 
-Download
-[VirtualBox](http://download.virtualbox.org/virtualbox/4.2.18/VirtualBox-4.2.18-88780-OSX.dmg)
-for Mac. Run the installer after it downloads.
+1. Download Railsinstaller from the <a href="http://railsinstaller.org" target="_blank">RailsInstaller</a> webpage.
+   Don't worry about watching the video. Just leave the download in your Downloads folder.
 
-Download [Vagrant](http://files.vagrantup.com/packages/db8e7a9c79b23264da129f55cf8569167fc22415/Vagrant-1.3.3.dmg) for Mac. Run the installer after it downloads.
+If you you have an older Mac and cannot run RailsInstaller, get Xcode and ask for help at the installfest.
 
+1. Go to the [Apple Developer Center](https://developer.apple.com/downloads), and click Register. Fill out the first page with your account information. The second page is a developer survey, which you can skip. Just go to the bottom and click "Continue".
 
-## OS X 10.5
-
-Go to the [Apple Developer Center](https://developer.apple.com/downloads),
-and click Register. Fill out the first page with your account information.
-The second page is a developer survey, which you can skip. Just go to the bottom and click
-"Continue".
-
-Once you have confirmed your developer account, you can download [Xcode
-3.1.4](http://adcdownload.apple.com/Developer_Tools/xcode_3.1.4_developer_tools/xcode314_2809_developerdvd.dmg).
-If that link doesn't work, go to the [downloads
-page](https://developer.apple.com/downloads) and search for "Xcode 3.1.4"
-
-
+2. Once you have confirmed your developer account, you can download [Xcode 3.1.4](http://adcdownload.apple.com/Developer_Tools/xcode_3.1.4_developer_tools/xcode314_2809_developerdvd.dmg). If that link doesn't work, go to the [downloads page](https://developer.apple.com/downloads) and search for "Xcode 3.1.4"
 
 ## Windows
 
-Note that unlike the OS X instructions, these are not multiple options - you
-should do all of the steps below.
+All Windows users should use a virtual machine.
 
-Download
-[VirtualBox](http://download.virtualbox.org/virtualbox/4.2.18/VirtualBox-4.2.18-88781-Win.exe)
-for Windows. Run the installer after it downloads. You can quit the application
-if it launches at the end of the installation.
+1. Download [VirtualBox](http://download.virtualbox.org/virtualbox/4.2.18/VirtualBox-4.2.18-88781-Win.exe) for Windows. Run the installer after it downloads. You can quit the application if it launches at the end of the installation.
 
-Download
-[Vagrant](http://files.vagrantup.com/packages/db8e7a9c79b23264da129f55cf8569167fc22415/Vagrant_1.3.3.msi)
-for Windows. Run the installer after it downloads. Agree to restart the computer if you're prompted to do so.
+2. Download [Vagrant](http://files.vagrantup.com/packages/db8e7a9c79b23264da129f55cf8569167fc22415/Vagrant_1.3.3.msi) for Windows. Run the installer after it downloads. Agree to restart the computer if you're prompted to do so.
 
-Download [GitHub for Windows](http://windows.github.com/) and run the installer.
-If prompted during installation, install the Microsoft .NET framework.
-If GitHub for Windows automatically launches after installation, quit the application.
+3. Download [GitHub for Windows](http://windows.github.com/) and run the installer. If prompted during installation, install the Microsoft .NET framework. If GitHub for Windows automatically launches after installation, quit the application.
 
+Then, follow the instructions in [VM Setup](/vm_setup).
 
 ## Linux
 
-Nothing to do yet. Come to the workshop on Friday.
-
-
+Make sure that Ruby is installed with your Linux distribution's package manager, and come to the installfest.

--- a/views/vm_setup.markdown
+++ b/views/vm_setup.markdown
@@ -1,0 +1,117 @@
+# Virtual Machine Setup
+
+Open a command prompt. See the [Using the Command Prompt](/command_prompt), for a refresher on how to start the command prompt.
+
+Download the Railsbridge Boston Virtual Machine with this command:
+
+    vagrant box add railsbridgebox http://s3.amazonaws.com/railsbridgeboston/railsbridgevm-4.0.box
+
+If you don't have Vagrant and VirtualBox working, just [download the image](http://s3.amazonaws.com/railsbridgeboston/railsbridgevm-4.0.box). Then come to the installfest and we'll help you get up and running. Once Vagrant and VirtualBox are set up, you can run
+
+    vagrant box add railsbridgebox file:///path/to/railsbridgevm-4.0.box
+
+To add the image from the already downloaded file.
+
+## Setting up a workspace
+
+Create a workspace directory for your Railsbridge tutorial.
+
+Go to your home directory:
+
+    cd ~
+
+Make a new directory for the workshop:
+
+    mkdir workspace
+
+Move into that directory:
+
+    cd workspace
+
+This directory will be shared between the virtual machine and your computer. Like sharing files between two real computers with Dropbox or Google Docs, files need to be saved in a place that both computers can see. Save all your work in the hands-on exercises here so they can be run in the virtual machine.
+
+## Starting the Virtual Machine
+
+Create and start your machine!
+
+This is a one-time step to create the virtual machine for the workshop.
+
+    vagrant init railsbridgebox
+
+Here is what you should see (approximately):
+
+```
+[choi@mini rbb]$ vagrant init railsbridgebox
+A `Vagrantfile` has been placed in this directory. You are now
+ready to `vagrant up` your first virtual environment! Please read
+the comments in the Vagrantfile as well as documentation on
+`vagrantup.com` for more information on using Vagrant.
+```
+
+Start the virtual machine:
+
+    vagrant up
+
+It will do something like this:
+```
+choi@mini rbb]$ vagrant up
+Bringing machine 'default' up with 'virtualbox' provider...
+[default] Importing base box 'railsbridgebox'...
+[default] Matching MAC address for NAT networking...
+[default] Setting the name of the VM...
+[default] Clearing any previously set forwarded ports...
+[default] Creating shared folders metadata...
+[default] Clearing any previously set network interfaces...
+[default] Preparing network interfaces based on configuration...
+[default] Forwarding ports...
+[default] -- 22 => 2222 (adapter 1)
+[default] -- 3000 => 3000 (adapter 1)
+[default] Booting VM...
+[default] Waiting for VM to boot. This can take a few minutes.
+[default] VM booted and ready for use!
+[default] Configuring and enabling network interfaces...
+[default] Mounting shared folders...
+[default] -- /vagrant
+```
+
+Connect to the virtual machine and start a command prompt: 
+
+    vagrant ssh
+
+You will see:
+```
+[choi@mini rbb]$ vagrant ssh
+Welcome to Ubuntu 12.04 LTS (GNU/Linux 3.2.0-23-generic-pae i686)
+
+ * Documentation:  https://help.ubuntu.com/
+
+Welcome to the Railsbridge Boston virtual machine!
+
+Everything you need for the Suggestotron tutorial is installed, including:
+
+- Ruby 2.0
+- Rails 4.0
+- sqlite3
+- heroku toolbelt
+- git
+
+Next steps:
+
+1. Create a SSH key
+2. Configure Git
+3. Create a Heroku account
+
+The ~/workspace directory from inside the VM shell is identical to the host
+directory of your VM workspace.
+
+When you start your Rails app, visit http://localhost:3000 in your web browser.
+
+Last login: Tue Aug 27 00:38:27 2013 from 10.0.2.2
+vagrant@precise32:~$ 
+```
+
+We will walk through creating an SSH key, configuring git, and creating a Heroku account in the workshop.  They are one-time steps.
+
+Run 'vagrant up' every time you start the virtual machine.
+
+Run 'vagrant ssh' every time you connect to the virtual machine.


### PR DESCRIPTION
Like the commit says, the instructions on how to init are mainly copied from the railsbridge/railsbridge-virtual-machine repo.

I'm using the rails 4.0 image S3 url -- don't know if we want to update the filename for the final version. I can also host a mirror if needed (i can set up a vhost for any subdomain like files.railsbridgeboston.org).

Stuff I'm wondering about:
1. Should we update the recommended VirtualBox and Vagrant versions to latest stable? The image works fine. Right now the Vagrant version recommended here is slightly ahead of the one in the railsbridge-virtual-machine repo.
2. can you even download Xcode 3.4 anymore? In any other situation, if someone walked in with a PPC or too-old-to-virtualize Intel Mac, I'd probably recommend installing Homebrew/Tigerbrew (OSX gcc command line tools only, not full Xcode) and updating Ruby that way, but I'm not sure it's likely any students will have a Mac that old. It's possible keeping that bit might just be distracting/confusing to people who don't need it.
