### PR TITLE
Finish renaming command prompt to command line

### DIFF
--- a/views/pre_workshop.markdown
+++ b/views/pre_workshop.markdown
@@ -47,7 +47,7 @@ If you you have an older Mac and cannot run RailsInstaller, get Xcode and ask fo
 
 ## <a name="windows">Windows</a>
 
-Windows is a different kind of operating system, so you will have to use a virtual machine. In particular, it doesn't have the same kind of command prompt. Since we are going to start and access the virtual machine by running Vagrant in a command prompt, we'll fix this by installing GitHub for Windows, which comes with an OS X and Linux-like "shell". You don't need to use the actual Github for Windows app in the workshop.
+Windows is a different kind of operating system, so you will have to use a virtual machine. In particular, it doesn't have the same kind of command line. Since we are going to start and access the virtual machine by running Vagrant from the command line, we'll fix this by installing GitHub for Windows, which comes with an OS X and Linux-like "shell". You don't need to use the actual Github for Windows app in the workshop.
 
 1. Download [VirtualBox](http://download.virtualbox.org/virtualbox/4.2.18/VirtualBox-4.2.18-88781-Win.exe) for Windows. Run the installer after it downloads. Start VirtualBox after installation to ensure that it launches.  You can quit once it starts.
 
@@ -62,7 +62,7 @@ Windows is a different kind of operating system, so you will have to use a virtu
 
 ## <a name="linux">Linux</a>
 
-First, check whether Ruby is already installed.  At a command prompt, type
+First, check whether Ruby is already installed.  At the command line, type
 `ruby -v`
 If Ruby is installed, you'll see something like
 <pre>ruby 2.0.0p353 (2013-11-22 revision 43784)</pre>

--- a/views/vm_setup.markdown
+++ b/views/vm_setup.markdown
@@ -4,7 +4,7 @@ Windows and OS X users need to set up the virtual machine they [downloaded](/pre
 
 
 ## Setting up a workspace
-Open a command prompt. See the [Using the Command Prompt](/command_prompt), for a refresher on how to start the command prompt.
+Open the command line. See the [Using the Command Line](http://docs.railsbridgeboston.org/ruby/command_line), for a refresher on how to start the command line.
 
 
 Create a workspace directory for your Railsbridge tutorial.


### PR DESCRIPTION
I noticed a change made by @danchoi a few months ago to replace the term "command prompt" with "command line". This fixes the remaining instances.

(I am to blame for adding some of the "command prompt" -- I thought the terminology was weird but was editing a page that used it I wanted to be consistent with what was there!)

This also, instead of linking to the `command_prompt` page in this site, links to the docs site's command line page, which looks nicer and has been recently updated. I think it's good to only have the information in one place. Nothing links to `command_prompt` here now, so anyone merging this can delete it. If anything important in it hasn't already made it to the page in `docs`, I can look at that.
