### PR TITLE
Update VirtualBox and Vagrant minor versions for September workshop

### DIFF
--- a/views/downloads.markdown
+++ b/views/downloads.markdown
@@ -30,20 +30,20 @@ Find the column for your OS, and download each file.
   <th>Linux (Ubuntu/Fedora)</th>
 </tr>
 <tr>
-  <td><a href="http://downloads.railsbridge.org/railsbridgevm-2014-05.box">May 2014 VM Image</a></td>
-  <td><a href="http://downloads.railsbridge.org/railsbridgevm-2014-05.box">May 2014 VM Image</a></td>
-  <td><a href="http://downloads.railsbridge.org/railsbridgevm-2014-05.box">May 2014 VM Image</a></td>
-  <td><a href="http://downloads.railsbridge.org/railsbridgevm-2014-05.box">May 2014 VM Image</a></td>
+  <td><a href="http://downloads.railsbridge.org/railsbridgevm-2014-09-rc1.box">September 2014 VM Image</a></td>
+  <td><a href="http://downloads.railsbridge.org/railsbridgevm-2014-09-rc1.box">September 2014 VM Image</a></td>
+  <td><a href="http://downloads.railsbridge.org/railsbridgevm-2014-09-rc1.box">September 2014 VM Image</a></td>
+  <td><a href="http://downloads.railsbridge.org/railsbridgevm-2014-09-rc1.box">September 2014 VM Image</a></td>
 </tr>
 <tr>
-  <td><a href="http://download.virtualbox.org/virtualbox/4.3.10/VirtualBox-4.3.10-93012-OSX.dmg">VirtualBox 4.3 Installer</a></td>
-  <td><a href="http://download.virtualbox.org/virtualbox/4.3.10/VirtualBox-4.3.10-93012-Win.exe">VirtualBox 4.3 Installer</a></td>
-  <td><a href="http://download.virtualbox.org/virtualbox/4.3.10/VirtualBox-4.3.10-93012-Win.exe">VirtualBox 4.3 Installer</a></td>
+  <td><a href="http://download.virtualbox.org/virtualbox/4.3.14/VirtualBox-4.3.14-95030-OSX.dmg">VirtualBox 4.3 Installer</a></td>
+  <td><a href="http://download.virtualbox.org/virtualbox/4.3.14/VirtualBox-4.3.14-95030-Win.exe">VirtualBox 4.3 Installer</a></td>
+  <td><a href="http://download.virtualbox.org/virtualbox/4.3.14/VirtualBox-4.3.14-95030-Win.exe">VirtualBox 4.3 Installer</a></td>
   <td><a href="https://www.virtualbox.org/wiki/Linux_Downloads">Choose your distro here</a></td>
 </tr>
 <tr>
-  <td><a href="https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.1.dmg">Vagrant 1.6 Installer</a></td>
-  <td><a href="https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.1.msi">Vagrant 1.6 Installer</a></td>
+  <td><a href="https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.3.dmg">Vagrant 1.6 Installer</a></td>
+  <td><a href="https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.3.msi">Vagrant 1.6 Installer</a></td>
   <td><a href="https://dl.bintray.com/mitchellh/vagrant/vagrant_1.5.4.msi">Vagrant 1.5 Installer</a></td>
   <td><a href="http://www.vagrantup.com/downloads.html">Choose your distro here</a></td>
 </tr>

--- a/views/installfest/vm_setup.markdown
+++ b/views/installfest/vm_setup.markdown
@@ -14,7 +14,7 @@ Before the workshop, you [downloaded](/downloads) the RailsBridge virtual machin
 
 *If you were unable to download the vm ahead of time, we have copies on USB drives.*
 
-In File Explorer or Finder, drag and drop "railsbridgevm-2014-05.box" from your downloads folder to your new workspace folder.
+In File Explorer or Finder, drag and drop "railsbridgevm-2014-09.box" from your downloads folder to your new workspace folder.
 
 Open your computer's command line. See the [Command Line page](/installfest/command_line) for instructions on how to open it.
 
@@ -32,7 +32,7 @@ If you've installed the RailsBridge VM from a previous workshop, delete it.  If 
 
 Type this:
 
-    `vagrant box add railsbridgebox ./railsbridgevm-2014-05.box`
+    `vagrant box add railsbridgebox ./railsbridgevm-2014-09.box`
 
 Then type:
 


### PR DESCRIPTION
These are the versions that will be used to build the VM. Looks like
only minor updates.

Pointed the actual download to 2014-09-rc1 now so TAs can test it - this
will be changed later when the final 2014-09 tag is ready. Put the final
filename in the vm_setup page (that should be the only step that needs to
use the filename).

Not much new in the VM except updating Rails to the latest 4.0 version.
Let me know if you want something added/fixed!
