### PR TITLE
Rename 'Civility Policy' -> 'Code of Conduct'

### DIFF
--- a/views/navbar.erb
+++ b/views/navbar.erb
@@ -23,7 +23,7 @@
               <li><a href="/workshop-info#schedule">Schedule</a></li>
               <li><a href="/workshop-info#organizers">Organizers</a></li>
               <li><a href="/workshop-info#instructors">Instructors</a></li>
-              <li><a href="/workshop-info#civility-policy">Civility Policy</a></li>
+              <li><a href="/workshop-info#code-of-conduct">Code of Conduct</a></li>
             </ul>
           </li>
 

--- a/views/workshop-info.erb
+++ b/views/workshop-info.erb
@@ -124,9 +124,9 @@
 <% @instructors = load_instructors_from_yaml %>
 <%= erb :"workshop_info/instructors" %>
 
-<div id="civility-policy" class="row">
+<div id="code-of-conduct" class="row">
   <div class="span12">
-    <h2>Civility Policy</h2>
+    <h2>Code of Conduct</h2>
   </div>
 </div>
 


### PR DESCRIPTION
Lots more organizations and conferences are adopting codes of conduct these days, which is awesome! If you're not up to speed here's a good example about why/how: https://blog.heroku.com/archives/2013/12/11/code_of_conduct

Unfortunately ours is under the less-common name "Civility Policy". This isn't where I would be looking for it, and, if I were new to the workshop, would make me wonder if differs from commonly-used wordings in some not-actually-adressing-harassment "just be awesome to each other" way. It doesn't! But I would have to read it carefully to check.

I think actually calling it a CoC would be better. What do other people think?
